### PR TITLE
Changed data-format to data-theme to support multiple themes

### DIFF
--- a/AspNetCore.ReCaptcha/ReCaptchaGenerator.cs
+++ b/AspNetCore.ReCaptcha/ReCaptchaGenerator.cs
@@ -12,7 +12,7 @@ namespace AspNetCore.ReCaptcha
             if (!string.IsNullOrEmpty(size))
                 content.AppendFormat(@" data-size=""{0}""", size);
             if (!string.IsNullOrEmpty(theme))
-                content.AppendFormat(@" data-format=""{0}""", theme);
+                content.AppendFormat(@" data-theme=""{0}""", theme);
             if (!string.IsNullOrEmpty(callback))
                 content.AppendFormat(@" data-callback=""{0}""", callback);
             if (!string.IsNullOrEmpty(errorCallback))


### PR DESCRIPTION
Change data-format to data-theme in ReCaptchaGenerator.cs

As stated here: https://developers.google.com/recaptcha/docs/display#render_param to make the reCAPTCHA box use dark theme instead of the "data-format" the "data-theme" parameter  has to be used.