### PR TITLE
Add support for disabling reCAPTCHA via configuration

### DIFF
--- a/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
+++ b/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace AspNetCore.ReCaptcha.Tests;
+
+public class ReCaptchaTagHelperTests
+{
+    private readonly ReCaptchaTagHelper _reCaptchaTagHelper;
+    private readonly ReCaptchaSettings _reCaptchaSettings;
+
+    public ReCaptchaTagHelperTests()
+    {
+        // Setup mocks
+        _reCaptchaSettings = new ReCaptchaSettings();
+
+        var mockReCaptchaSettingsSnapshot = new Mock<IOptionsSnapshot<ReCaptchaSettings>>();
+        mockReCaptchaSettingsSnapshot.Setup(m => m.Value)
+            .Returns(_reCaptchaSettings);
+        var reCaptchaSettingsSnapshot = mockReCaptchaSettingsSnapshot.Object;
+        
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IOptions<ReCaptchaSettings>>(reCaptchaSettingsSnapshot);
+
+        ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var featureCollection = new FeatureCollection();
+
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(m => m.RequestServices)
+            .Returns(serviceProvider);
+        mockHttpContext.Setup(m => m.Features)
+            .Returns(featureCollection);
+        HttpContext httpContext = mockHttpContext.Object;
+
+        var viewContext = new ViewContext
+        {
+            HttpContext = httpContext
+        };
+
+        // Setup SUT
+        _reCaptchaTagHelper = new ReCaptchaTagHelper
+        {
+            ViewContext = viewContext
+        };
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void ProcessConsideredEnabledSetting(bool enabled, bool expectModified)
+    {
+        // Arrange
+        TagHelperContext tagHelperContext = CreateTagHelperContext();
+        TagHelperOutput tagHelperOutput = CreateTagHelperOutput();
+
+        _reCaptchaSettings.Enabled = enabled;
+
+        // Act
+        _reCaptchaTagHelper.Process(tagHelperContext, tagHelperOutput);
+        
+        // Assert
+        Assert.Equal(expectModified, tagHelperOutput.Content.IsModified);
+    }
+
+    private static TagHelperOutput CreateTagHelperOutput()
+    {
+        const string tagName = "foo-bar";
+        var attributes = new TagHelperAttributeList();
+        Task<TagHelperContent> GetChildContentAsync(bool useCachedResult, HtmlEncoder encoder) => 
+            Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+
+        return new TagHelperOutput(tagName, attributes, GetChildContentAsync);
+    }
+
+    private static TagHelperContext CreateTagHelperContext()
+    {
+        var allAttributes = new TagHelperAttributeList();
+        var items = new Dictionary<object, object>();
+        const string uniqueId = "fizz-buzz";
+
+        return new TagHelperContext(allAttributes, items, uniqueId);
+    }
+}

--- a/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
+++ b/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
@@ -56,7 +56,7 @@ public class ReCaptchaTagHelperTests
     [Theory]
     [InlineData(true, true)]
     [InlineData(false, false)]
-    public void ProcessConsideredEnabledSetting(bool enabled, bool expectModified)
+    public void ProcessConsidersEnabledSetting(bool enabled, bool expectModified)
     {
         // Arrange
         TagHelperContext tagHelperContext = CreateTagHelperContext();

--- a/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
+++ b/AspNetCore.ReCaptcha.Tests/ReCaptchaTagHelperTests.cs
@@ -28,7 +28,7 @@ public class ReCaptchaTagHelperTests
         var reCaptchaSettingsSnapshot = mockReCaptchaSettingsSnapshot.Object;
         
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<IOptions<ReCaptchaSettings>>(reCaptchaSettingsSnapshot);
+        serviceCollection.AddSingleton(reCaptchaSettingsSnapshot);
 
         ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 

--- a/AspNetCore.ReCaptcha/ReCaptchaSettings.cs
+++ b/AspNetCore.ReCaptcha/ReCaptchaSettings.cs
@@ -19,5 +19,11 @@ namespace AspNetCore.ReCaptcha
         public Dictionary<string, double> ActionThresholds { get; set; } = new Dictionary<string, double>();
         public Func<Type, IStringLocalizerFactory, IStringLocalizer> LocalizerProvider { get; set; }
         public Uri RecaptchaBaseUrl { get; set; } = GoogleReCaptchaBaseUrl;
+
+        /// <summary>
+        /// Determines whether Google reCAPTCHA is enabled / enforced. Defaults to <code>true</code> for backward
+        /// compatibility with existing application deployments.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
     }
 }

--- a/AspNetCore.ReCaptcha/ReCaptchaTagHelper.cs
+++ b/AspNetCore.ReCaptcha/ReCaptchaTagHelper.cs
@@ -44,7 +44,7 @@ namespace AspNetCore.ReCaptcha
             if (Id.ToLower() == "submit")
                 throw new ArgumentException("id can't be named submit");
 
-            var settings = ViewContext.HttpContext.RequestServices.GetRequiredService<IOptions<ReCaptchaSettings>>().Value;
+            var settings = ViewContext.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<ReCaptchaSettings>>().Value;
 
             if (!settings.Enabled)
             {

--- a/AspNetCore.ReCaptcha/ReCaptchaTagHelper.cs
+++ b/AspNetCore.ReCaptcha/ReCaptchaTagHelper.cs
@@ -38,9 +38,15 @@ namespace AspNetCore.ReCaptcha
             if (Id.ToLower() == "submit")
                 throw new ArgumentException("id can't be named submit");
 
-            Language ??= ViewContext.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.UICulture.TwoLetterISOLanguageName;
-
             var settings = ViewContext.HttpContext.RequestServices.GetRequiredService<IOptions<ReCaptchaSettings>>().Value;
+
+            if (!settings.Enabled)
+            {
+                // Nothing to do - reCAPTCHA is not enabled / enforced.
+                return;
+            }
+
+            Language ??= ViewContext.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.UICulture.TwoLetterISOLanguageName;
 
             var content = settings.Version switch
             {


### PR DESCRIPTION
Adds support for an `Enabled` property in the reCAPTCHA configuration. This defaults to `true` for backward compatibility with existing applications.

If set to `false`, the HTML for the reCAPTCHA widget will not be generated, and the `[ValidateReCaptcha]` attribute implementation will not attempt to validate the reCAPTCHA.